### PR TITLE
add git ref to clone installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ Tools can be updated right from the instance itself.
 Update the OpenShift installer from `master` using:
 
 ```shell
-$ update-installer
+$ update-installer [repo-owner] [branch]
+```
+
+Update the OpenShift installer from `https://github.com/repo-owner/installer.git` `branch` using:
+
+```shell
+$ update-installer repo-owner branch
 ```
 
 Update the RHCOS image using:

--- a/tools/update-installer
+++ b/tools/update-installer
@@ -5,11 +5,14 @@ set -o pipefail
 
 echo "Building installer"
 
+REPO_OWNER="${1:-openshift}"
+BRANCH="${2:-master}"
 GOPATH=$(mktemp -d)
 export GOPATH
 
-git clone https://github.com/openshift/installer.git $GOPATH/src/github.com/openshift/installer
+git clone https://github.com/"${REPO_OWNER}"/installer.git $GOPATH/src/github.com/openshift/installer
 cd $GOPATH/src/github.com/openshift/installer
+git checkout "${BRANCH}"
 
 hack/get-terraform.sh
 TAGS=libvirt_destroy hack/build.sh


### PR DESCRIPTION
@ironcladlou ~this will be necessary for installer CI, we'll run `update-installer pr-owner pr-branch` before running `create-cluster`~

_actually_ we won't need this for CI, since the installer repo is already cloned I'll scp the openshift-installer binary, but adding the git ref option is useful anyways? 