### PR TITLE
document that google project is configurable and add kubectl binary to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Interact with your cluster with `oc`.
 
 Tools can be updated right from the instance itself.
 
-Update the OpenShift installer from `master` using:
+Update the OpenShift installer from `https://github.com/openshift/installer.git` `master` using:
 
 ```shell
-$ update-installer [repo-owner] [branch]
+$ update-installer
 ```
 
 Update the OpenShift installer from `https://github.com/repo-owner/installer.git` `branch` using:
@@ -60,12 +60,23 @@ The source image is `centos-7` with [nested virtualization enabled](https://clou
 $ packer build openshift4-libvirt-source.json
 ```
 
+To override any default variable value, for example, Google Project ID:
+
+```shell
+$ packer build -var 'project=your-google-project-id' openshift4-libvirt-source.json
+```
+
 ### Provisioned image
 
 The provisioned image implements all the [OpenShift libvirt HOWTO](https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md) requirements.
 
 ```shell
 $ packer build openshift4-libvirt.json
+```
+To override any default variable value, for example, Google Project ID:
+
+```shell
+$ packer build -var 'project=your-google-project-id' openshift4-libvirt.json
 ```
 
 ## Advanced usage

--- a/provision.sh
+++ b/provision.sh
@@ -105,6 +105,9 @@ curl -OL https://github.com/openshift/origin/releases/download/v3.11.0/openshift
 tar -zxf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
 sudo mv $HOME/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc /usr/local/bin
 
+echo "Installing kubectl binary"
+sudo ln -s /usr/local/bin/oc /usr/local/bin/kubectl
+
 # Install a default installer
 update-installer
 


### PR DESCRIPTION
@ironcladlou , this PR:
 * documents that the google project id is configurable via the command line, so we can create this image family in our ci project.
* adds `kubectl` binary to provision.sh, because the extended test suite`openshift/smoke-4` requires `kubectl`