### PR TITLE
edit baseDomain, create openshift.conf not tectonic.conf

### DIFF
--- a/openshift4-libvirt.json
+++ b/openshift4-libvirt.json
@@ -14,6 +14,7 @@
       "image_family": "{{ user `image_family` }}",
       "ssh_username": "packer",
       "min_cpu_platform": "Intel Haswell",
+      "machine_type": "n1-standard-2",
       "disk_type": "pd-ssd",
       "disk_size": 256
     }

--- a/provision.sh
+++ b/provision.sh
@@ -77,7 +77,7 @@ sudo firewall-cmd --zone=trusted --add-port=16509/tcp
 # Enable NetworkManager DNS overlay
 # https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#set-up-networkmanager-dns-overlay
 sudo sed -i -z 's/\[main\]\n/\[main\]\ndns=dnsmasq\n/' /etc/NetworkManager/NetworkManager.conf
-echo server=/testing/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/tectonic.conf
+echo server=/openshift.testing/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
 sudo systemctl restart NetworkManager
 
 # Configure the default libvirt storage pool
@@ -92,9 +92,6 @@ sudo virsh pool-define /dev/stdin <<EOF
 EOF
 sudo virsh pool-start default
 sudo virsh pool-autostart default
-
-echo "Installing terraform-provider-libvirt"
-sudo bash -c 'GOBIN=/usr/local/bin go get -u github.com/dmacvicar/terraform-provider-libvirt'
 
 # Install a default RHCOS image
 update-rhcos-image

--- a/tools/create-cluster
+++ b/tools/create-cluster
@@ -21,6 +21,7 @@ export BASE_DOMAIN=openshift.testing
 export CLUSTER_NAME="${NAME}"
 export CLUSTER_ID=$(uuidgen --random)
 export PUB_SSH_KEY="${SSH_KEY}.pub"
+export BUILD=$(curl -s https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/builds.json | jq -r '.builds[0]')
 
 cat > "${CLUSTER_DIR}/install-config.yml" << EOF
 baseDomain: "${BASE_DOMAIN}"
@@ -44,7 +45,7 @@ platform:
   libvirt:
     URI: qemu+tcp://192.168.122.1/system
     defaultMachinePlatform:
-      image: https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/47.212/redhat-coreos-maipo-47.212-qemu.qcow2.gz
+      image: "https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/${BUILD}/redhat-coreos-maipo-${BUILD}-qemu.qcow2.gz"
     masterIPs: null
     network:
       if: tt0


### PR DESCRIPTION
@ironcladlou 
* I was getting out of memory errors when building, increaed to n1-standard-2
* updating base domain passed to NetworkManager, and updated name of file to openshift.conf
* updated create-cluster to find latest rhcos image
* updated provision.sh, no longer have to install terraform-provider-libvirt (and in fact this caused my libvirt machines to _not_ get assigned ip addresses, as far as I can tell)