### PR TITLE
update install-config.yml|yaml, and TAGS=libvirt_destroy|libvirt

### DIFF
--- a/tools/create-cluster
+++ b/tools/create-cluster
@@ -23,7 +23,7 @@ export CLUSTER_ID=$(uuidgen --random)
 export PUB_SSH_KEY="${SSH_KEY}.pub"
 export BUILD=$(curl -s https://releases-rhcos.svc.ci.openshift.org/storage/releases/maipo/builds.json | jq -r '.builds[0]')
 
-cat > "${CLUSTER_DIR}/install-config.yml" << EOF
+cat > "${CLUSTER_DIR}/install-config.yaml" << EOF
 baseDomain: "${BASE_DOMAIN}"
 clusterID:  "${CLUSTER_ID}"
 machines:

--- a/tools/update-installer
+++ b/tools/update-installer
@@ -14,7 +14,7 @@ git clone https://github.com/"${REPO_OWNER}"/installer.git $GOPATH/src/github.co
 cd $GOPATH/src/github.com/openshift/installer
 git checkout "${BRANCH}"
 
-TAGS=libvirt_destroy hack/build.sh
+TAGS=libvirt hack/build.sh
 
 sudo mv bin/openshift-install /usr/local/bin
 


### PR DESCRIPTION
@ironcladlou This PR picks up a few recent changes in installer.  The install-config.yml is deprecated in favor of install-config.yaml.  Also, when running in libvirt, must now build installer with TAGS=libvirt.  