### PR TITLE
tools/create-cluster: Remove tee from cluster create

### DIFF
--- a/tools/create-cluster
+++ b/tools/create-cluster
@@ -55,4 +55,4 @@ openshift-install --dir="$CLUSTER_DIR" create manifests
 yq w -i $CLUSTER_DIR/manifests/cluster-ingress-02-config.yml spec[domain] apps.$BASE_DOMAIN
 
 export TF_VAR_libvirt_master_memory=11024
-openshift-install create cluster --log-level=debug --dir="$CLUSTER_DIR" 2>&1 | tee /tmp/installer.log
+openshift-install create cluster --log-level=debug --dir="$CLUSTER_DIR"


### PR DESCRIPTION
We don't need to redirect the logs since now installer
auto create it under $INSTALL_DIR/.openshift_install.log file