### PR TITLE
create-cluster: Wait another 30m for cluster to initialize

### DIFF
--- a/tools/create-cluster
+++ b/tools/create-cluster
@@ -60,4 +60,4 @@ openshift-install --dir="$CLUSTER_DIR" create manifests
 yq w -i $CLUSTER_DIR/manifests/cluster-ingress-02-config.yml spec[domain] apps.$BASE_DOMAIN
 
 export TF_VAR_libvirt_master_memory=11024
-openshift-install create cluster --log-level=debug --dir="$CLUSTER_DIR"
+openshift-install create cluster --log-level=debug --dir="$CLUSTER_DIR" || openshift-install wait-for install-complete --log-level=debug --dir="$CLUSTER_DIR"


### PR DESCRIPTION
Seems at the moment [we're hitting the 30m timeout](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_installer/1863/pull-ci-openshift-installer-master-e2e-libvirt/469) almost 100% of the time. Let's ask the installer to wait another 30m if it fails.

Once the Installer supports specifying time to wait for, we'll use that here to wait for only 10 additional minutes.