### PR TITLE
add release override instruction, gcp create/teardown scripts

### DIFF
--- a/IMAGES.md
+++ b/IMAGES.md
@@ -1,0 +1,36 @@
+# OpenShift 4.0 libvirt on GCP Images
+
+Currently, images are maintained and pushed to `openshift-gce-devel` project for all OpenShift developers to use.   
+If you have access to OpenShift GCE account, you should not build images.  For access see [onboarding docs](https://mojo.redhat.com/docs/DOC-1081313)
+For all others, you'll need to create these images in your GCE project and update all scripts accordingly.
+
+## Images
+
+Images are built with [Packer](https://www.packer.io). Override variables as necessary.
+
+### Source image
+
+The source image is `rhel8` with [nested virtualization enabled](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances#restrictions).
+
+```shell
+$ packer build openshift4-libvirt-source.json
+```
+
+To override any default variable value, for example, Google Project ID:
+
+```shell
+$ packer build -var 'project=your-google-project-id' openshift4-libvirt-source.json
+```
+
+### Provisioned image
+
+The provisioned image implements all the [OpenShift libvirt HOWTO](https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md) requirements.
+
+```shell
+$ packer build openshift4-libvirt.json
+```
+To override any default variable value, for example, Google Project ID:
+
+```shell
+$ packer build -var 'project=your-google-project-id' openshift4-libvirt.json
+```

--- a/README.md
+++ b/README.md
@@ -1,57 +1,68 @@
 # OpenShift 4.0 libvirt on GCP
 
-Create an [OpenShift 4.0](https://github.com/openshift/installer) cluster in a single GCP instance.
+Create an [OpenShift 4.X](https://github.com/openshift/installer) cluster in a single GCP instance.
 
-## Create a cluster
+### Prerequisites
 
-**If the images are built and available in your project/zone, all you need to get started is the `gcloud` CLI tool.**
+Images are built and maintained in openshift-gce-devel GCE project.  If you are an OpenShift developer and have access to openshift-gce-devel GCE project,
+all you need to get started is the [gcloud CLI tool](https://cloud.google.com/sdk/docs/downloads-yum)    
+For developers not in OpenShift organization, see [here](https://github.com/ironcladlou/openshift4-libvirt-gcp/blob/rhel8/IMAGES.md)
+for information on images, and substitute `your-gce-project` for `openshift-gce-devel` in all scripts. 
 
-First, create network and firewall rules.
+### Create GCP instance
+
+First, create network and firewall rules in GCP and then the GCP instance.
+```
+Note: this script uses scp to copy pull-secret to gcp instance.  Alternative is to
+add pull-secret to metadata when creating the instance.  However, metadata is printed
+in the gcp console.  This is why this setup uses scp instead. 
+```
+Check out `create-gcp-resources.sh` for individual commands or run the script like so:
 
 ```shell
-$ gcloud compute networks create "${INSTANCE}" \
-  --subnet-mode=custom \
-  --bgp-routing-mode=regional
-
-$ gcloud compute networks subnets create "${INSTANCE}" \
-  --network "${INSTANCE}" \
-  --range=10.0.0.0/9
-
-$ gcloud compute firewall-rules create "${INSTANCE}" \
-  --network "${INSTANCE}" \
-  --allow tcp:22,icmp
+$ export INSTANCE=mytest
+$ export GCP_USER=<your gcp username>, used to scp pull-secret to $HOME/pull-secret in gcp instance
+$ export PULL_SECRET=/path/to/pull-secret-one-liner.json
+$ ./create-gcp-resources.sh
 ```
 
-Then, create the instance.
+### Find an available release payload image
+
+You need to provide an OVERRIDE release payload that you have access to.
+For public images see [ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/) and
+[quay.io/ocp-dev-preview](https://quay.io/repository/openshift-release-dev/ocp-release?tab=tags) 
+or for internal images see [CI release images](https://openshift-release.svc.ci.openshift.org/)     
+example release images:
+* quay.io/openshift-release-dev/ocp-release:4.4.0-rc.2-x86_64 (public)
+* registry.svc.ci.openshift.org/ocp/release:4.5.0-0.ci-2020-03-16-194422 (internal)
+
+### Create nested libvirt cluster - 3 masters, 2 workers
+
+Connect to the instance using SSH and create a cluster named `$CLUSTER_NAME` using latest payload built from CI.
+Install directory will be populated at `$HOME/clusters/$CLUSTER_NAME`
 
 ```shell
-$ gcloud compute instances create "${INSTANCE}" \
-  --image-family openshift4-libvirt \
-  --zone us-east1-c \
-  --min-cpu-platform "Intel Haswell" \
-  --machine-type n1-standard-16 \
-  --boot-disk-type pd-ssd --boot-disk-size 256GB \
-  --network "${INSTANCE}" \
-  --subnet "${INSTANCE}" \
-  --metadata-from-file openshift-pull-secret=openshift-pull-secret.json
+$ gcloud beta compute ssh --zone "us-east1-c" $INSTANCE --project "openshift-gce-devel"
+$ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=registry.svc.ci.openshift.org/ocp/release:whatever create-cluster $CLUSTER_NAME
 ```
 
-Connect to the instance using SSH and create a cluster named `nested`.
+### Tear Down Cluster
 
+You can tear down and relaunch easily within your gcp instance like so:
 ```shell
-$ create-cluster nested
+$ gcloud beta compute ssh --zone "us-east1-c" $INSTANCE --project "openshift-gce-devel"
+$ openshift-install destroy cluster --dir ~/clusters/$ClUSTER_NAME && rm -rf ~/clusters/$CLUSTER_NAME
 ```
 
-*IMPORTANT* Tear down and clean up GCP.
+### Tear Down and Clean Up GCP.
 
+Clean up your GCP resources when you are done with your development cluster.
+Check out `teardown-gcp.sh` for individual commands or run the script like so:
 ```shell
-$ gcloud compute instances delete "${INSTANCE}"
-$ gcloud compute firewall-rules delete "${INSTANCE}"
-$ gcloud compute networks subnets delete "${INSTANCE}"
-$ gcloud compute networks delete "${INSTANCE}"
+$ INSTANCE=<your gcp instance name> ./teardown-gcp.sh
 ```
 
-Interact with your cluster with `oc`.
+Interact with your cluster with `oc` while connected via ssh to your gcp instance. 
 
 ### Updating the installer
 
@@ -60,46 +71,18 @@ Tools can be updated right from the instance itself.
 Update the OpenShift installer from `https://github.com/openshift/installer.git` `master` using:
 
 ```shell
+$ gcloud beta compute ssh --zone "us-east1-c" $INSTANCE --project "openshift-gce-devel"
 $ update-installer
 ```
 
 Update the OpenShift installer from `https://github.com/repo-owner/installer.git` `branch` using:
 
 ```shell
+$ gcloud beta compute ssh --zone "us-east1-c" $INSTANCE --project "openshift-gce-devel"
 $ update-installer repo-owner branch
-```
-
-## Images
-
-Images are built with [Packer](https://www.packer.io). Override variables as necessary.
-
-### Source image
-
-The source image is `rhel8` with [nested virtualization enabled](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances#restrictions).
-
-```shell
-$ packer build openshift4-libvirt-source.json
-```
-
-To override any default variable value, for example, Google Project ID:
-
-```shell
-$ packer build -var 'project=your-google-project-id' openshift4-libvirt-source.json
-```
-
-### Provisioned image
-
-The provisioned image implements all the [OpenShift libvirt HOWTO](https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md) requirements.
-
-```shell
-$ packer build openshift4-libvirt.json
-```
-To override any default variable value, for example, Google Project ID:
-
-```shell
-$ packer build -var 'project=your-google-project-id' openshift4-libvirt.json
 ```
 
 ## Advanced usage
 
 It's possible to ignore all the defaults and helpers and simply use the image as a stable base for libvirt installer development.
+You can use `openshift-install` binary without the `create-cluster` if you prefer. 

--- a/create-gcp-resources.sh
+++ b/create-gcp-resources.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+echo "Creating GCP resources"
+if [[ -z "$INSTANCE" ]] || [[ -z "$PULL_SECRET" ]] || [[ -z "$GCP_USER" ]]; then
+    echo the following environment variables must be provided:
+    echo "\$INSTANCE to name gcp resources"
+    echo "\$PULL_SECRET path to your pull-secret"
+    echo "\$GCP_USER your gcp username to scp pull-secret to gcp instance"
+    exit 1
+fi
+if [[ -z "$PULL_SECRET" ]]; then
+    echo "\$PULL_SECRET path must be provided"
+    exit 1
+fi
+if [[ -z "$GCP_USER" ]]; then
+    echo "\$GCP_USER your gcp username must be provided, to scp pull-secret to gcp instance"
+    exit 1
+fi
+set -euo pipefail
+set -x
+gcloud compute networks create "${INSTANCE}" \
+  --subnet-mode=custom \
+  --bgp-routing-mode=regional
+
+gcloud compute networks subnets create "${INSTANCE}" \
+  --network "${INSTANCE}" \
+  --range=10.0.0.0/9
+
+gcloud compute firewall-rules create "${INSTANCE}" \
+  --network "${INSTANCE}" \
+  --allow tcp:22,icmp
+
+
+gcloud compute instances create "${INSTANCE}" \
+  --image-family openshift4-libvirt \
+  --zone us-east1-c \
+  --min-cpu-platform "Intel Haswell" \
+  --machine-type n1-standard-16 \
+  --boot-disk-type pd-ssd --boot-disk-size 256GB \
+  --network "${INSTANCE}" \
+  --subnet "${INSTANCE}"
+
+ZONE=$(gcloud config get-value compute/zone)
+PROJECT=$(gcloud config get-value project)
+gcloud compute --project "${PROJECT}" scp \
+  --quiet \
+  --zone "${ZONE}" \
+  -- "${PULL_SECRET}" "${GCP_USER}"@"${INSTANCE}":"${HOME}"/pull-secret

--- a/teardown-gcp.sh
+++ b/teardown-gcp.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+set -u
+set -o pipefail
+
+echo "Cleaning up GCP"
+if [[ -z "$INSTANCE" ]]; then
+     echo "\$INSTANCE must be provided"
+fi
+echo "This script will remove all $INSTANCE GCP resources"
+echo "Do you want to continue (Y/n)?"
+read x
+if [ "$x" != "Y" ]; then
+    exit 0
+fi
+set -x
+gcloud compute instances delete "${INSTANCE}" --quiet
+gcloud compute firewall-rules delete "${INSTANCE}" --quiet
+gcloud compute networks subnets delete "${INSTANCE}" --quiet
+gcloud compute networks delete "${INSTANCE}" --quiet

--- a/tools/create-cluster
+++ b/tools/create-cluster
@@ -20,6 +20,7 @@ fi
 export BASE_DOMAIN=openshift.testing
 export CLUSTER_NAME="${NAME}"
 export PUB_SSH_KEY="${SSH_KEY}.pub"
+PULL_SECRET=$(cat "${HOME}/pull-secret")
 
 cat > "${CLUSTER_DIR}/install-config.yaml" << EOF
 apiVersion: v1
@@ -29,7 +30,7 @@ compute:
   architecture: amd64
   name: worker
   platform: {}
-  replicas: 1
+  replicas: 2
 controlPlane:
   hyperthreading: Enabled
   architecture: amd64
@@ -53,7 +54,7 @@ platform:
     network:
       if: tt0
 publish: External
-pullSecret: '$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/openshift-pull-secret -H "Metadata-Flavor: Google")'
+pullSecret: $(echo \'"${PULL_SECRET}"\')
 sshKey: |
   $(cat "${PUB_SSH_KEY}")
 EOF


### PR DESCRIPTION
* Add a teardown-gcp script
* Increase to 2 workers
* update README, move images info to IMAGES.md
* For successful install, you have to override the release image.  Otherwise see errors in bootstrap node like:
```
Error reading manifest 4.5 in registry.svc.ci.openshift.org/origin/release: manifest unknown: manifest unknown
```