### PR TITLE
update how to set libvirt master memory add wait-for installer-complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Note: this script uses scp to copy pull-secret to gcp instance.  Alternative is 
 add pull-secret to metadata when creating the instance.  However, metadata is printed
 in the gcp console.  This is why this setup uses scp instead. 
 ```
-Check out `create-gcp-resources.sh` for individual commands or run the script like so:
+You can either run the commands from `create-gcp-resources.sh` individually or run the script like so:
 
 ```shell
 $ export INSTANCE=mytest
-$ export GCP_USER=<your gcp username>, used to scp pull-secret to $HOME/pull-secret in gcp instance
+$ export GCP_USER=<whatever name you login as to gcp instance>, used to scp pull-secret to $HOME/pull-secret in gcp instance
 $ export PULL_SECRET=/path/to/pull-secret-one-liner.json
 $ ./create-gcp-resources.sh
 ```

--- a/provision.sh
+++ b/provision.sh
@@ -89,6 +89,7 @@ curl -OL https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/o
 tar -zxf oc.tar.gz
 rm -fr oc.tar.gz
 sudo mv $HOME/oc /usr/local/bin
+sudo ln -s /usr/local/bin/oc /usr/local/bin/kubectl
 
 # Install a default installer
 update-installer

--- a/teardown-gcp.sh
+++ b/teardown-gcp.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
-set -e
-set -u
-set -o pipefail
 
-echo "Cleaning up GCP"
+bold=$(tput bold)
+bright=$(tput setaf 14)
+reset=$(tput sgr0)
+
+echo_bright() {
+    echo "${bold}${bright}$1${reset}"
+}
+
+echo_bright "Cleaning up GCP"
 if [[ -z "$INSTANCE" ]]; then
      echo "\$INSTANCE must be provided"
 fi
-echo "This script will remove all $INSTANCE GCP resources"
-echo "Do you want to continue (Y/n)?"
+echo "This script will remove all ${bright}${bold}$INSTANCE${reset} GCP resources"
+echo "${bold}Do you want to continue (Y/n)?${reset}"
 read x
 if [ "$x" != "Y" ]; then
     exit 0

--- a/tools/create-cluster
+++ b/tools/create-cluster
@@ -12,6 +12,10 @@ if [ -d "${CLUSTER_DIR}" ]; then
 else
   mkdir -p ${CLUSTER_DIR}
 fi
+if [[ -z "$OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE" ]]; then
+    echo "\$OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE must be provided"
+    exit 1
+fi
 # Generate a default SSH key if one doesn't exist
 SSH_KEY="${HOME}/.ssh/id_rsa"
 if [ ! -f $SSH_KEY ]; then
@@ -62,7 +66,12 @@ EOF
 # Create manifests and modify route domain
 openshift-install --dir="$CLUSTER_DIR" create manifests
 # Workaround for https://github.com/openshift/installer/issues/1007
-yq w -i $CLUSTER_DIR/manifests/cluster-ingress-02-config.yml spec[domain] apps.$BASE_DOMAIN
+# Add custom domain to cluster-ingress
+yq write --inplace $CLUSTER_DIR/manifests/cluster-ingress-02-config.yml spec[domain] apps.$BASE_DOMAIN
 
-export TF_VAR_libvirt_master_memory=11024
-openshift-install create cluster --log-level=debug --dir="$CLUSTER_DIR"
+# Add master memory to 12 GB
+# This is only valid for openshift 4.3 onwards
+yq write --inplace ${CLUSTER_DIR}/openshift/99_openshift-cluster-api_master-machines-0.yaml spec.providerSpec.value[domainMemory] 14336
+
+openshift-install create cluster --log-level=debug --dir="$CLUSTER_DIR" || true
+openshift-install wait-for install-complete --log-level=debug --dir="$CLUSTER_DIR"


### PR DESCRIPTION
/cc @praveenkumar 
/cc @ironcladlou 

* update how libvirt master memory is set, this no longer works: `TF_VAR_libvirt_master_memory` (see here: https://github.com/code-ready/snc/blob/master/snc.sh#L236-L238) 
* add an `openshift-install wait-for install-complete` to the create-cluster script
* minor README, script docs change