### PR TITLE
Sync provision.sh with latest installer doc

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -25,23 +25,13 @@ if [[ ! -e /usr/local/bin/yq ]]; then
 fi
 
 # Enable IP forwarding
-# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#enable-ip-forwarding
+# https://github.com/openshift/installer/tree/master/docs/dev/libvirt#enable-ip-forwarding
 sudo sysctl net.ipv4.ip_forward=1
 echo "net.ipv4.ip_forward = 1" | sudo tee /etc/sysctl.d/99-ipforward.conf
 sudo sysctl -p /etc/sysctl.d/99-ipforward.conf
 
-# Enable non-root access to libvirt stuff
-# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#make-sure-you-have-permissions-for-qemusystem
-sudo bash -c 'cat > /etc/polkit-1/rules.d/80-libvirt.rules' << EOF
-polkit.addRule(function(action, subject) {
-  if (action.id == "org.libvirt.unix.manage" subject.isInGroup("google-sudoers")) {
-      return polkit.Result.YES;
-  }
-});
-EOF
-
 # Configure libvirt to accept TCP connections
-# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#configure-libvirt-to-accept-tcp-connections
+# https://github.com/openshift/installer/tree/master/docs/dev/libvirt#configure-libvirt-to-accept-tcp-connections
 sudo bash -c 'cat >> /etc/libvirt/libvirtd.conf' << EOF
 listen_tls = 0
 listen_tcp = 1
@@ -61,29 +51,17 @@ sudo modprobe kvm_intel nested=1
 sudo systemctl restart libvirtd
 # Set up iptables and firewalld
 # TODO: discover the ports
-sudo firewall-cmd --add-rich-rule='rule family=ipv4 source address=192.168.126.0/24 destination address=192.168.122.1 port port=16509 protocol=tcp accept' --permanent --zone=libvirt
+sudo firewall-cmd --permanent --add-rich-rule "rule service name="libvirt" reject"
+sudo firewall-cmd --permanent --zone=libvirt --add-service=libvirt
 sudo firewall-cmd --zone=libvirt --add-service=libvirt --permanent
 
 # Enable NetworkManager DNS overlay
-# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#set-up-networkmanager-dns-overlay
+# https://github.com/openshift/installer/tree/master/docs/dev/libvirt#set-up-networkmanager-dns-overlay
 echo -e "[main]\ndns=dnsmasq" | sudo tee /etc/NetworkManager/conf.d/openshift.conf
 echo server=/openshift.testing/192.168.126.1 | sudo tee /etc/NetworkManager/dnsmasq.d/openshift.conf
 # Create new domain for ingress to make sure it able to resolve auth route URL
 echo address=/.apps.openshift.testing/192.168.126.51 | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift.conf
 sudo systemctl restart NetworkManager
-
-# Configure the default libvirt storage pool
-# https://github.com/openshift/installer/blob/master/docs/dev/libvirt-howto.md#configure-default-libvirt-storage-pool
-sudo virsh pool-define /dev/stdin <<EOF
-<pool type='dir'>
-  <name>default</name>
-  <target>
-    <path>/var/lib/libvirt/images</path>
-  </target>
-</pool>
-EOF
-sudo virsh pool-start default
-sudo virsh pool-autostart default
 
 echo "Installing oc client"
 cd $HOME


### PR DESCRIPTION
libvirt configuration for the installer has changed a bit since this
script was created, and the doc has moved. This commit adjusts
provision.sh so that it follows the latest recommendations from
https://github.com/openshift/installer/tree/master/docs/dev/libvirt

The storage pool instructions were removed in https://github.com/openshift/installer/commit/cfcd2f4eabe3
The polkit instructions were removed in https://github.com/openshift/installer/commit/869f9e924

Note: This is untested for now, Praveen told me he could do that soon, otherwise I'll do it.