### PR TITLE
Use dnf versionlock for qemu-kvm package

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -7,9 +7,10 @@ set -x
 # Install tools
 sudo mv /tmp/tools/* /usr/local/bin
 
-sudo dnf install -y libvirt libvirt-devel libvirt-client git libvirt-daemon-kvm bind-utils jq gcc-c++
+sudo dnf install -y python3-dnf-plugin-versionlock
 # https://github.com/ironcladlou/openshift4-libvirt-gcp/issues/29
-sudo dnf remove -y qemu-kvm && sudo dnf install -y qemu-kvm-2.12.0-88.module+el8.1.0+5708+85d8e057.3
+sudo dnf versionlock add qemu-kvm-2.12.0-88.module+el8.1.0+5708+85d8e057.3
+sudo dnf install -y libvirt libvirt-devel libvirt-client git libvirt-daemon-kvm bind-utils jq gcc-c++
 
 # Install golang
 curl -L https://dl.google.com/go/go1.13.8.linux-amd64.tar.gz -o go1.13.8.linux-amd64.tar.gz


### PR DESCRIPTION
There is issue with latest version of qemu-version and right now
only working package `88.module+el8.1.0+5708+85d8e057.3` so locking
this version, it will avoid to update this package during yum update or
automatic image update.