### PR TITLE
Add packages which used for snc or crc

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -12,6 +12,9 @@ sudo dnf remove -y dnf-automatic
 
 sudo dnf install -y libvirt libvirt-devel libvirt-client git libvirt-daemon-kvm bind-utils jq gcc-c++ golang
 
+# Install tools needed by crc/snc to workaround intermittent `yum install` network failures during some CI runs
+sudo dnf install -y make tmux unzip podman rsync libguestfs-tools-c zstd httpd-tools patch
+
 # Install yq to manipulate manifest file created by installer.
 if [[ ! -e /usr/local/bin/yq ]]; then
     curl -L https://github.com/mikefarah/yq/releases/download/2.2.1/yq_linux_amd64 -o yq


### PR DESCRIPTION
Recently we are seeing multiple failure on the CI because of following
error. Better to install all the packages before hand so no need to run
`yum install` or minimize the use of installing packages.

```
Red Hat Enterprise Linux 8 for x86_64 - Supplem 232  B/s | 1.0 kB     00:04
Errors during downloading metadata for repository 'rhui-rhel-8-for-x86_64-supplementary-rhui-rpms':
  - Status code: 404 for https://cds.rhel.updates.googlecloud.com/pulp/repos/content/dist/rhel8/rhui/8/x86_64/supplementary/os/repodata/7ddfb35cceeed63522dbf53f062dfd7526907c89f3dfa1146ab814aee77811fb-filelists.xml.gz (IP: 35.190.247.1)
  - Status code: 404 for https://cds.rhel.updates.googlecloud.com/pulp/repos/content/dist/rhel8/rhui/8/x86_64/supplementary/os/repodata/ecaf2b75f8c25ce599b6b6c3bd08f2e569e79b822e14a69a5f5b70dac3bb5e53-primary.xml.gz (IP: 35.190.247.1)
  - Status code: 404 for https://cds.rhel.updates.googlecloud.com/pulp/repos/content/dist/rhel8/rhui/8/x86_64/supplementary/os/repodata/2d994e18464a3c4ac93b6756961ac59ff947fbc2416ea477a653caa223da120b-updateinfo.xml.gz (IP: 35.190.247.1)
Error: Failed to download metadata for repo 'rhui-rhel-8-for-x86_64-supplementary-rhui-rpms': Yum repo downloading error: Downloading error(s): repodata/7ddfb35cceeed63522dbf53f062dfd7526907c89f3dfa1146ab814aee77811fb-filelists.xml.gz - Cannot download, all mirrors were already tried without success; repodata/ecaf2b75f8c25ce599b6b6c3bd08f2e569e79b822e14a69a5f5b70dac3bb5e53-primary.xml.gz - Cannot download, all mirrors were already tried without success; repodata/2d994e18464a3c4ac93b6756961ac59ff947fbc2416ea477a653caa223da120b-updateinfo.xml.gz - Cannot download, all mirrors were already tried without success; repodata/f5ccc0ba10a5cd01ec4edac6b200cd48e8c0ab2262e05e7b6e0c7347a06e9b14-comps.xml - Cannot download, all mirrors were already tried without success
```