### PR TITLE
Provision: Enable virtnetworkd service

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -35,6 +35,8 @@ auth_tcp="none"
 EOF
 
 sudo systemctl enable --now virtproxyd-tcp.socket
+# Enable the virtnetworkd service so that default network active as part of startup
+sudo systemctl enable --now virtnetworkd.service
 
 sudo bash -c 'cat >> /etc/modprobe.d/kvm.conf' << EOF
 options kvm_intel nested=1


### PR DESCRIPTION
Without this service installer not able to perform something like following
```
$ virsh -c qemu+tcp://192.168.122.1/system uri
error: failed to connect to the hypervisor
error: unable to connect to server at '192.168.122.1:16509': Connection refused
```

It is happen because with modular nature of libvirt now default network only available once `virtnetworkd` service is active and it can be activated by `virtnetworkd.socket` but then user have execute `sudo virsh net-list` to activate it using this socket. With this service enable it is now available on boot and following request works
```
$ virsh -c qemu+tcp://192.168.122.1/system uri
qemu+tcp://192.168.122.1/system
```

It also resolve CI failure like
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-api-provider-libvirt/260/pull-ci-openshift-cluster-api-provider-libvirt-master-e2e-libvirt/1678777871411187712