### PR TITLE
Remove networkType option from install-config

### DIFF
--- a/tools/create-cluster
+++ b/tools/create-cluster
@@ -65,7 +65,6 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.126.0/24
-  networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16
 platform:


### PR DESCRIPTION
Till now we used `OpenShiftSDN` as network type which is now depericated so better to remove it so it always take default whatever it is.